### PR TITLE
Changed validation of open-parameter

### DIFF
--- a/update.php
+++ b/update.php
@@ -43,7 +43,7 @@
 	    }
 
 	    $newOpenStatus = $_POST[OPEN_STATUS_PARAMETER];
-	    if ($newOpenStatus != false && $newOpenStatus != true) {
+	    if ($newOpenStatus != '0' && $newOpenStatus != '1') {
 	    	respond(400, "The parameter '" . OPEN_STATUS_PARAMETER . "' has to be either 0(closed) or 1(open)");
 	    }
 


### PR DESCRIPTION
because PHP is sometimes a bit… surprising. In this case the old check passes for the input „bla“ even though it should reject all non-boolean-values. The new check is a bit more strict by allowing only „0“ and „1“, even rejecting „false“ or „true“.

For a little demonstration of the problem, run the following script:

``` php
<?php
function output($text, $value) {
    echo $text . ": " . ($value ? 'true' : 'false') . "\n";
}

function testString($string) {
    echo "--------------------------------\n";
    output($string." ==  false", ($string == false));
    output($string." ==  true ", ($string == true));
    echo "\n";
    output($string." != '0'   ", ($string != '0'));
    output($string." != '1'   ", ($string != '1'));
    echo "\n";
    output($string." !=  false", ($string != false));
    output($string." !=  true ", ($string != true));
    echo "\n";
    output($string." !== false", ($string !== false));
    output($string." !== true ", ($string !== true));
    echo "\n";
    output($string." rejected by old check", ($string != false && $string != true));
    output($string." rejected by new check", ($string != '0' && $string != '1'));
    echo "\n";
}
testString("bla");
testString("true");
testString("1");
testString("0");
```
